### PR TITLE
added functionality for text before ShowImage

### DIFF
--- a/Ridgeside SMAPI Component 1.3/RidgesideVillage/ModEntry.cs
+++ b/Ridgeside SMAPI Component 1.3/RidgesideVillage/ModEntry.cs
@@ -49,7 +49,7 @@ namespace RidgesideVillage
         private void OnGameLaunched(object sender, EventArgs e)
         {
             TileActionHandler.Initialize(this);
-            ImageMenu.Setup();
+            ImageMenu.Setup(Helper);
 
 
             Config = Helper.ReadConfig<ModConfig>();

--- a/Ridgeside SMAPI Component 1.3/RidgesideVillage/TileActionHandler.cs
+++ b/Ridgeside SMAPI Component 1.3/RidgesideVillage/TileActionHandler.cs
@@ -62,7 +62,7 @@ namespace RidgesideVillage
                 //Log.Debug($"FOUND ACTION {actionString}");
                 foreach (var key in tileActions.Keys)
                 {
-                    if (actionString.Contains(key))
+                    if (actionString.StartsWith(key))
                     {
                         tileActions[key](actionString);
                         break;


### PR DESCRIPTION
format is `ShowImage "path/to/file" scale [i18nkey]` (the i18nkey is only needed when a text should be shown before the image)

"path/to/file" needs the " surrounding it and can contain spaces, scale is a float, i18nkey is a string **without** "" (and it mustn't contain spaces), corresponding to a key in the i18n .json

An example would be `ShowImage "LooseSprites/RSVContestWinnerPic" 1.0 HotelCounter.Booking.Question`

