### PR TITLE
Move empty loads

### DIFF
--- a/Ridgeside Development/[CP] Ridgeside Village/Data/Events/EventExtras.json
+++ b/Ridgeside Development/[CP] Ridgeside Village/Data/Events/EventExtras.json
@@ -2,24 +2,7 @@
 "Changes": [
 
 
-//Load blank json files for events
-	{
-		"LogName": "Load Blank Jsons for Events",
-		"Action": "Load",
-		"Target": "Data/Events/Custom_Ridgeside_RidgesideVillage, Data/Events/Custom_Ridgeside_AguarBasement, Data/Events/Custom_Ridgeside_AguarLab, Data/Events/Custom_Ridgeside_AlissaHouse, Data/Events/Custom_Ridgeside_AlissaShed, Data/Events/Custom_Ridgeside_BertHouse, Data/Events/Custom_Ridgeside_EzekielHouse, Data/Events/Custom_Ridgeside_FreddieHouse, Data/Events/Custom_Ridgeside_JericHouse, Data/Events/Custom_Ridgeside_KennethHouse, Data/Events/Custom_Ridgeside_LennyHouse, Data/Events/Custom_Ridgeside_LogCabinHotelLobby, Data/Events/Custom_Ridgeside_LogCabinHotel2ndFloor, Data/Events/Custom_Ridgeside_LogCabinHotel3rdFloor, Data/Events/Custom_Ridgeside_LolaShed, Data/Events/Custom_Ridgeside_MaddieHouse, Data/Events/Custom_Ridgeside_PikaHouse, Data/Events/Custom_Ridgeside_RSVCableCar, Data/Events/Custom_Ridgeside_RSVCliff, Data/Events/Custom_Ridgeside_RSVNinjaHouse, Data/Events/Custom_Ridgeside_Ridge, Data/Events/Custom_Ridgeside_ShiroHouse, Data/Events/Custom_Ridgeside_MysticFalls1, Data/Events/Custom_Ridgeside_MysticFalls2, Data/Events/Custom_Ridgeside_MysticFalls3, Data/Events/Custom_Ridgeside_RSVAbandonedHouse, Data/Events/Custom_Ridgeside_RidgeForest, Data/Events/Custom_Ridgeside_LogCabinEventHall, Data/Events/Custom_Ridgeside_BlairHouse, Data/Events/Custom_Ridgeside_FayeHouse, Data/Events/Custom_Ridgeside_PurpleMansion, Data/Events/Custom_Ridgeside_PurpleMansion2ndFloor, Data/Events/Custom_Ridgeside_3Bros, Data/Events/Custom_Ridgeside_3Bros2ndFloor, Data/Events/Custom_Ridgeside_RSVSewers, Data/Events/Custom_Ridgeside_PaulaClinic, Data/Events/Custom_Ridgeside_RidgeFalls, Data/Events/Custom_Ridgeside_RSVTheHike, Data/Events/Custom_Ridgeside_RSVGreenhouse1, Data/Events/Custom_Ridgeside_RSVGreenhouse2, Data/Events/Custom_Ridgeside_RSVSpiritRealm, Data/Events/Custom_Ridgeside_IanHouse, Data/Events/Custom_Ridgeside_RSVSummitFarm",
-		"FromFile": "Data/LoadData/EmptyJson.json",
-	},
-
-//Load blank AdventureGuild json for events
-	{
-		"LogName": "Load blank AdventureGuild.json for events",
-		"Action": "Load",
-		"Target": "Data/Events/AdventureGuild",
-		"FromFile": "Data/LoadData/EmptyJson.json",
-		"When": {
-			"HasMod: |contains=FlashShifter.StardewValleyExpandedCP, Wolf.Marlon": false,
-		}
-	},
+//Loading blank jsons for events moved to the code component so SMAPI load resolution can be used.
 
 //Load Loose sprites
 	{

--- a/Ridgeside Development/[CP] Ridgeside Village/Data/InterModCompat/StardewValleyExpanded.json
+++ b/Ridgeside Development/[CP] Ridgeside Village/Data/InterModCompat/StardewValleyExpanded.json
@@ -33,13 +33,7 @@
 		"When": { "HasMod: |contains=FlashShifter.StardewValleyExpandedCP": true, },
 	},
 
-	//Custom Wedding Patches (Not sure if this actually works)
-	{
-		"Action": "Load",
-		"Target": "Data/CustomWeddingGuestPositions",
-		"FromFile": "Data/LoadData/EmptyJson.json",
-		"When": { "HasMod: |contains=FlashShifter.StardewValleyExpandedCP": false, },
-	},
+	//Custom Wedding Patches (Not sure if this actually works). Blank json load moved to code component so smapi conflict resolution can be used.
 	{
 		"Action": "EditData",
 		"Target": "Data/CustomWeddingGuestPositions",

--- a/Ridgeside SMAPI Component 2.0/RidgesideVillage/AssetManager.cs
+++ b/Ridgeside SMAPI Component 2.0/RidgesideVillage/AssetManager.cs
@@ -10,11 +10,10 @@ namespace RidgesideVillage
         internal static void LoadEmptyJsons(AssetRequestedEventArgs e)
         {
             // Load in files for events
-#warning - fix in Stardew 1.6 for string event IDs.
             if (e.NameWithoutLocale.IsEquivalentTo("Data/Events/AdventureGuild")
                 || e.NameWithoutLocale.BaseName.StartsWith(CUSTOM_EVENTS))
             {
-                e.LoadFrom(() => new Dictionary<int, string>(), AssetLoadPriority.Low);
+                e.LoadFrom(() => new Dictionary<string, string>(), AssetLoadPriority.Low);
             }
             else if (e.NameWithoutLocale.IsEquivalentTo("Data/CustomWeddingGuestPositions"))
             { // Zero clue what this is, is this fully implemented?

--- a/Ridgeside SMAPI Component 2.0/RidgesideVillage/AssetManager.cs
+++ b/Ridgeside SMAPI Component 2.0/RidgesideVillage/AssetManager.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using StardewModdingAPI.Events;
+using StardewModdingAPI.Utilities;
+
+namespace RidgesideVillage
+{
+    internal static class AssetManager
+    {
+        private static readonly string CUSTOM_EVENTS = PathUtilities.NormalizeAssetName("Data/Events/Custom_Ridgeside");
+        internal static void LoadEmptyJsons(AssetRequestedEventArgs e)
+        {
+            // Load in files for events
+#warning - fix in Stardew 1.6 for string event IDs.
+            if (e.NameWithoutLocale.IsEquivalentTo("Data/Events/AdventureGuild")
+                || e.NameWithoutLocale.BaseName.StartsWith(CUSTOM_EVENTS))
+            {
+                e.LoadFrom(() => new Dictionary<int, string>(), AssetLoadPriority.Low);
+            }
+            else if (e.NameWithoutLocale.IsEquivalentTo("Data/CustomWeddingGuestPositions"))
+            { // Zero clue what this is, is this fully implemented?
+                e.LoadFrom(() => new Dictionary<string, string>(), AssetLoadPriority.Low);
+            }
+        }
+    }
+}

--- a/Ridgeside SMAPI Component 2.0/RidgesideVillage/ModEntry.cs
+++ b/Ridgeside SMAPI Component 2.0/RidgesideVillage/ModEntry.cs
@@ -38,6 +38,8 @@ namespace RidgesideVillage
             helper.Events.GameLoop.GameLaunched += OnGameLaunched;
             helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
             helper.Events.GameLoop.DayStarted += OnDayStarted;
+
+            helper.Events.Content.AssetRequested += OnAssetRequested;
             
             BgUtils.Initialize(this);
 
@@ -85,6 +87,11 @@ namespace RidgesideVillage
 
             Helper.ConsoleCommands.Add("LocationModData", "show ModData of given location", printLocationModData);
             Helper.ConsoleCommands.Add("remove_equipment", "Remove all clothes and equipment from farmer", RemoveEquipment);
+        }
+
+        private void OnAssetRequested(object sender, AssetRequestedEventArgs e)
+        {
+            AssetManager.LoadEmptyJsons(e);
         }
 
         private void OnDayStarted(object sender, DayStartedEventArgs e)


### PR DESCRIPTION
Moves some loading of empty jsons to the smapi component to use smapi's new conflict resolution. This should make compat with other mods easier in the future.