### PR TITLE
Expose map entries under clickableComponents

### DIFF
--- a/Ridgeside SMAPI Component 2.0/RidgesideVillage/Map/MapMenu.cs
+++ b/Ridgeside SMAPI Component 2.0/RidgesideVillage/Map/MapMenu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -46,6 +46,11 @@ namespace RidgesideVillage
             this.image = mapTexture;
 
             MapData = new MapData();
+            this.allClickableComponents = new List<ClickableComponent>();
+            foreach (var entry in this.MapData.Locations.Values)
+            {
+                this.allClickableComponents.Add(new ClickableComponent(entry.AreaRect, entry.Text));
+            }
 
             TopLeft = Utility.getTopLeftPositionForCenteringOnScreen((int)(image.Width), (int)(image.Height));
             MapRectangle = new Rectangle((int)TopLeft.X, (int)TopLeft.Y, (int)(image.Width), (int)(image.Height));

--- a/Ridgeside SMAPI Component 2.0/RidgesideVillage/Map/RSVWorldMap.cs
+++ b/Ridgeside SMAPI Component 2.0/RidgesideVillage/Map/RSVWorldMap.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -70,6 +70,11 @@ namespace RidgesideVillage
             this.image = mapTexture;
 
             MapData = new MapData("RSV/RSVWorldMapData");
+            this.allClickableComponents = new List<ClickableComponent>();
+            foreach (var entry in this.MapData.Locations.Values)
+            {
+                this.allClickableComponents.Add(new ClickableComponent(entry.AreaRect, entry.Text));
+            }
             NPCLocationData = new WorldMapAreas();
 
             TopLeft = Utility.getTopLeftPositionForCenteringOnScreen((int)(image.Width), (int)(image.Height));


### PR DESCRIPTION
This exposes the selectable map areas for RSV, this allows other mods to view the selectable areas and hook into the click or mouse over logic.
Note: Other mods would need check the boundary boxes themselves, this just exposes the areas.