### PR TITLE
Fixes people charging more at high friendship

### DIFF
--- a/Ridgeside Development/[CP] Ridgeside Village/Data/Shops.json
+++ b/Ridgeside Development/[CP] Ridgeside Village/Data/Shops.json
@@ -316,6 +316,7 @@
 							"Condition": "PLAYER_FRIENDSHIP_POINTS Current Jeric 2000"
 						},		
 					],
+					"PriceModifierMode": "Minimum",
 					"SalableItemTags": [
 						"category_fertilizer",
 						"category_seeds"
@@ -492,6 +493,7 @@
 							"Condition": "PLAYER_FRIENDSHIP_POINTS Current Pika 2000"
 						},		
 					],
+					"PriceModifierMode": "Minimum",
 					"SalableItemTags": [
 						"category_cooking",
 						"category_ingredients",
@@ -571,6 +573,7 @@
 							"Condition": "PLAYER_FRIENDSHIP_POINTS Current Pika 2000"
 						},		
 					],
+					"PriceModifierMode": "Minimum",
 
 					"Items": [
 						//Unlockable Recipes
@@ -697,6 +700,7 @@
 							"Condition": "PLAYER_FRIENDSHIP_POINTS Current Lola 2000"
 						},		
 					],
+					"PriceModifierMode": "Minimum",
 					"SalableItemTags": [
 						"category_monster_loot",
 						"category_ring",
@@ -1447,6 +1451,7 @@
 							"Condition": "PLAYER_FRIENDSHIP_POINTS Current Malaya 2000"
 						},		
 					],
+					"PriceModifierMode": "Minimum",
 					"SalableItemTags": [
 						"category_cooking",
 						"category_ingredients",
@@ -1507,7 +1512,7 @@
 							"Condition": "PLAYER_FRIENDSHIP_POINTS Current Malaya 2000"
 						},		
 					],
-
+					"PriceModifierMode": "Minimum",
 					"Items": [
 						//Recipes
 						{
@@ -1591,7 +1596,7 @@
 							"Condition": "PLAYER_FRIENDSHIP_POINTS Current Kimpoi 2000"
 						},		
 					],
-
+					"PriceModifierMode": "Minimum",
 					"SalableItemTags": [
 						"category_fertilizer",
 						"category_seeds"
@@ -1669,7 +1674,7 @@
 							"Condition": "PLAYER_FRIENDSHIP_POINTS Current Lorenzo 2000"
 						},		
 					],
-
+					"PriceModifierMode": "Minimum",
 					"SalableItemTags": [
 						"category_fish",
 						"category_egg",


### PR DESCRIPTION
At present shops are either stacking or maximizing prices if multiple multipliers are present. Adding this instead uses the minimum, per user in #bug-reports