### PR TITLE
Poly compat and Jio fix

### DIFF
--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Alissa.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Alissa.json
@@ -35,7 +35,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Alissa": "Married",
 		"Query: ('{{Alissa}}' = 'enabled' AND '{{SeasonalAlissaToken}}' = 'true') OR ('{{Alissa}}' = 'festivals always')": true,
    },
@@ -47,8 +46,7 @@
 	 "LogName": "Alissa Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Alissa": "Married",
 		"Query: ('{{Alissa}}' = 'enabled' AND '{{SeasonalAlissaToken}}' = 'true') OR ('{{Alissa}}' = 'festivals always')": true,
 		"Kimpoi": "enabled, festivals only",

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Anton.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Anton.json
@@ -51,8 +51,7 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
+		"IsOddYear": true,	
    	"Relationship:Anton": "Married",
 		"Anton": "enabled, festivals only",
 		"Paula": "enabled, festivals only",
@@ -65,8 +64,7 @@
 	 "LogName": "Anton Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {		
    	"Relationship:Anton": "Married",
 		"Anton": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Blair.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Blair.json
@@ -36,7 +36,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Blair": "Married",
 		"Carmen": "enabled, festivals only",
    },
@@ -48,8 +47,7 @@
 	 "LogName": "Blair Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Blair": "Married",
 		"Blair": "enabled, festivals only",
 		"Query: ('{{Sean}}' = 'enabled' AND '{{SeasonalSeanToken}}' = 'true') OR ('{{Sean}}' = 'festivals always')": true,

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Bryle.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Bryle.json
@@ -49,7 +49,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Bryle": "Married",
 		"Bryle": "enabled, festivals only",
 		"Faye": "enabled, festivals only",
@@ -62,8 +61,7 @@
 	 "LogName": "Bryle Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Bryle": "Married",
 		"Bryle": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Corine.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Corine.json
@@ -57,7 +57,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Corine": "Married",
 		"Query: ('{{Corine}}' = 'enabled' AND '{{SeasonalCorineToken}}' = 'true') OR ('{{Corine}}' = 'festivals always')": true,
 		"Query: ('{{Ysabelle}}' = 'enabled' AND '{{SeasonalYsabelleToken}}' = 'true') OR ('{{Ysabelle}}' = 'festivals always')": true,
@@ -72,7 +71,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Corine": "Married",
 		"Query: ('{{Corine}}' = 'enabled' AND '{{SeasonalCorineToken}}' = 'true') OR ('{{Corine}}' = 'festivals always')": true,
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Daia.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Daia.json
@@ -50,12 +50,11 @@
 
 //Free Love back-up
 	{
-	 "LogName": "Daia Spirit's Eve Dialogue Changes (Free Love back-up) Y1",
+	 "LogName": "Daia Spirit's Eve Dialogue Changes (Free Love back-up)",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
 		"HasSeenEvent": 75160263,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Daia": "Married",
    },
    "Entries": {

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Faye.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Faye.json
@@ -64,8 +64,7 @@
 	 "LogName": "Faye Spirit's Eve Dialogue Change (Free Love back-up) Y1",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Faye": "Married",
 		"IsOddYear": true,
 		"Faye": "enabled, festivals only",
@@ -78,8 +77,7 @@
 	 "LogName": "Faye Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Faye": "Married",
 		"IsOddYear": false,
 		"Faye": "enabled, festivals only",

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Flor.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Flor.json
@@ -29,8 +29,7 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
+		"IsOddYear": true,	
    	"Relationship:Flor": "Married",
 		"Jeric": "enabled, festivals only",
    },
@@ -42,8 +41,7 @@
 	 "LogName": "Flor Spirit's Eve Dialogue Changes (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Flor": "Married",
 		"Flor": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Ian.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Ian.json
@@ -35,7 +35,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Ian": "Married",
 		"Query: ('{{Ian}}' = 'enabled' AND '{{SeasonalIanToken}}' = 'true') OR ('{{Ian}}' = 'festivals always')": true,
 		"Query: ('{{Sean}}' = 'enabled' AND '{{SeasonalSeanToken}}' = 'true') OR ('{{Sean}}' = 'festivals always')": true,
@@ -48,8 +47,7 @@
 	 "LogName": "Ian Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Ian": "Married",
 		"Query: ('{{Ian}}' = 'enabled' AND '{{SeasonalIanToken}}' = 'true') OR ('{{Ian}}' = 'festivals always')": true,
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Irene.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Irene.json
@@ -48,7 +48,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Irene": "Married",
 		"Irene": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Jeric.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Jeric.json
@@ -19,7 +19,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Jeric": "Married",
 		"Jeric": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Jio.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Jio.json
@@ -32,7 +32,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"HasSeenEvent": 75160263,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Jio": "Married",
 		"Jio": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/June.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/June.json
@@ -33,7 +33,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:June": "Married",
 		"June": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Kenneth.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Kenneth.json
@@ -33,7 +33,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Kenneth": "Married",
 		"IsOddYear": true,
 		"Kenneth": "enabled, festivals only",
@@ -47,7 +46,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Kenneth": "Married",
 		"IsOddYear": false,
 		"Kenneth": "enabled, festivals only",

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Kiarra.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Kiarra.json
@@ -34,7 +34,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Kiarra": "Married",
 		"Query: ('{{Kiarra}}' = 'enabled' AND '{{SeasonalKiarraToken}}' = 'true') OR ('{{Kiarra}}' = 'festivals always')": true,
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Maddie.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Maddie.json
@@ -49,7 +49,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Maddie": "Married",
 		"Maddie": "enabled, festivals only",
 		"Query: ('{{Corine}}' = 'enabled' AND '{{SeasonalCorineToken}}' = 'true') OR ('{{Corine}}' = 'festivals always')": true,
@@ -64,7 +63,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Maddie": "Married",
 		"Jeric": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Paula.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Paula.json
@@ -52,7 +52,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Paula": "Married",
 		"Paula": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Philip.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Philip.json
@@ -35,7 +35,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Philip": "Married",
 		"IsOddYear": true,
 		"Philip": "enabled, festivals only",
@@ -50,7 +49,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Philip": "Married",
 		"IsOddYear": false,
 		"Philip": "enabled, festivals only",

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Sean.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Sean.json
@@ -34,7 +34,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Sean": "Married",
 		"Query: ('{{Sean}}' = 'enabled' AND '{{SeasonalSeanToken}}' = 'true') OR ('{{Sean}}' = 'festivals always')": true,
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Shiro.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Shiro.json
@@ -35,7 +35,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Shiro": "Married",
 		"IsOddYear": true,
 		"Shiro": "enabled, festivals only",
@@ -50,7 +49,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Shiro": "Married",
 		"IsOddYear": false,
 		"Shiro": "enabled, festivals only",

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Ysabelle.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Ysabelle.json
@@ -58,7 +58,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Ysabelle": "Married",
 		"Query: ('{{Ysabelle}}' = 'enabled' AND '{{SeasonalYsabelleToken}}' = 'true') OR ('{{Ysabelle}}' = 'festivals always')": true,
 		"Query: ('{{Corine}}' = 'enabled' AND '{{SeasonalCorineToken}}' = 'true') OR ('{{Corine}}' = 'festivals always')": true,
@@ -73,7 +72,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Ysabelle": "Married",
 		"Query: ('{{Ysabelle}}' = 'enabled' AND '{{SeasonalYsabelleToken}}' = 'true') OR ('{{Ysabelle}}' = 'festivals always')": true,
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Zayne.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Zayne.json
@@ -61,7 +61,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Zayne": "Married",
 		"IsOddYear": true,
 		"Zayne": "enabled, festivals only",
@@ -75,7 +74,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Zayne": "Married",
 		"IsOddYear": false,
 		"Zayne": "enabled, festivals only",

--- a/Ridgeside Development/[CP] Ridgeside Village/Assets/MarriageDialogue/MarriageDialogueJio.json
+++ b/Ridgeside Development/[CP] Ridgeside Village/Assets/MarriageDialogue/MarriageDialogueJio.json
@@ -76,7 +76,7 @@
 	"funLeave_Jio": "{{i18n:Jio.MarriageDialogue.funLeave_Jio.{{Random: 1, 2, 3, 4}}}}",
 
 //Returning
-	"funReturn_Jio": "{{i18n:Jio.MarriageDialogue.funReturn_Jio_1-1}}[Rafseazz.RSVCP_Arugula_Roll Rafseazz.RSVCP_Fried_Fish_a_la_Ridge Rafseazz.RSVCP_Honey_Ginger_Whitefish Rafseazz.RSVCP_Zesty_Tuna Rafseazz.RSVCP_Fried_Mountain_Greens Rafseazz.RSVCP_Ginger_Arugula_Fried_Rice]#$b#{{i18n:Jio.MarriageDialogue.funReturn_Jio_1-2}}",
+	"funReturn_Jio": "{{i18n:Jio.MarriageDialogue.funReturn.Jio_1-1}}[Rafseazz.RSVCP_Arugula_Roll Rafseazz.RSVCP_Fried_Fish_a_la_Ridge Rafseazz.RSVCP_Honey_Ginger_Whitefish Rafseazz.RSVCP_Zesty_Tuna Rafseazz.RSVCP_Fried_Mountain_Greens Rafseazz.RSVCP_Ginger_Arugula_Fried_Rice]#$b#{{i18n:Jio.MarriageDialogue.funReturn_Jio.1-2}}",
 
 //One kid
 	"OneKid_0": "{{i18n:Jio.MarriageDialogue.OneKid_0}}",


### PR DESCRIPTION
Fixes Poly compat in RSV Seasonals to not require Free Love itself (since to be married to them and not be spouse means a poly mod is used) as well as fixes a no translation bug with Jio.