### PR TITLE
Poly compat and Jio fix

### DIFF
--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Alissa.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Alissa.json
@@ -35,7 +35,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Alissa": "Married",
 		"Query: ('{{Alissa}}' = 'enabled' AND '{{SeasonalAlissaToken}}' = 'true') OR ('{{Alissa}}' = 'festivals always')": true,
    },
@@ -47,8 +46,7 @@
 	 "LogName": "Alissa Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Alissa": "Married",
 		"Query: ('{{Alissa}}' = 'enabled' AND '{{SeasonalAlissaToken}}' = 'true') OR ('{{Alissa}}' = 'festivals always')": true,
 		"Kimpoi": "enabled, festivals only",

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Anton.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Anton.json
@@ -51,8 +51,7 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
+		"IsOddYear": true,	
    	"Relationship:Anton": "Married",
 		"Anton": "enabled, festivals only",
 		"Paula": "enabled, festivals only",
@@ -65,8 +64,7 @@
 	 "LogName": "Anton Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {		
    	"Relationship:Anton": "Married",
 		"Anton": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Blair.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Blair.json
@@ -36,7 +36,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Blair": "Married",
 		"Carmen": "enabled, festivals only",
    },
@@ -48,8 +47,7 @@
 	 "LogName": "Blair Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Blair": "Married",
 		"Blair": "enabled, festivals only",
 		"Query: ('{{Sean}}' = 'enabled' AND '{{SeasonalSeanToken}}' = 'true') OR ('{{Sean}}' = 'festivals always')": true,

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Bryle.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Bryle.json
@@ -49,7 +49,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Bryle": "Married",
 		"Bryle": "enabled, festivals only",
 		"Faye": "enabled, festivals only",
@@ -62,8 +61,7 @@
 	 "LogName": "Bryle Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Bryle": "Married",
 		"Bryle": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Corine.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Corine.json
@@ -57,7 +57,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Corine": "Married",
 		"Query: ('{{Corine}}' = 'enabled' AND '{{SeasonalCorineToken}}' = 'true') OR ('{{Corine}}' = 'festivals always')": true,
 		"Query: ('{{Ysabelle}}' = 'enabled' AND '{{SeasonalYsabelleToken}}' = 'true') OR ('{{Ysabelle}}' = 'festivals always')": true,
@@ -72,7 +71,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Corine": "Married",
 		"Query: ('{{Corine}}' = 'enabled' AND '{{SeasonalCorineToken}}' = 'true') OR ('{{Corine}}' = 'festivals always')": true,
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Daia.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Daia.json
@@ -50,12 +50,11 @@
 
 //Free Love back-up
 	{
-	 "LogName": "Daia Spirit's Eve Dialogue Changes (Free Love back-up) Y1",
+	 "LogName": "Daia Spirit's Eve Dialogue Changes (Free Love back-up)",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
 		"HasSeenEvent": 75160263,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Daia": "Married",
    },
    "Entries": {

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Faye.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Faye.json
@@ -64,8 +64,7 @@
 	 "LogName": "Faye Spirit's Eve Dialogue Change (Free Love back-up) Y1",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Faye": "Married",
 		"IsOddYear": true,
 		"Faye": "enabled, festivals only",
@@ -78,8 +77,7 @@
 	 "LogName": "Faye Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Faye": "Married",
 		"IsOddYear": false,
 		"Faye": "enabled, festivals only",

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Flor.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Flor.json
@@ -29,8 +29,7 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
+		"IsOddYear": true,	
    	"Relationship:Flor": "Married",
 		"Jeric": "enabled, festivals only",
    },
@@ -42,8 +41,7 @@
 	 "LogName": "Flor Spirit's Eve Dialogue Changes (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Flor": "Married",
 		"Flor": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Ian.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Ian.json
@@ -35,7 +35,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Ian": "Married",
 		"Query: ('{{Ian}}' = 'enabled' AND '{{SeasonalIanToken}}' = 'true') OR ('{{Ian}}' = 'festivals always')": true,
 		"Query: ('{{Sean}}' = 'enabled' AND '{{SeasonalSeanToken}}' = 'true') OR ('{{Sean}}' = 'festivals always')": true,
@@ -48,8 +47,7 @@
 	 "LogName": "Ian Spirit's Eve Dialogue Change (Free Love back-up) Y2",
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
-   "When": {
-		"HasMod": "aedenthorn.FreeLove",
+   "When": {	
    	"Relationship:Ian": "Married",
 		"Query: ('{{Ian}}' = 'enabled' AND '{{SeasonalIanToken}}' = 'true') OR ('{{Ian}}' = 'festivals always')": true,
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Irene.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Irene.json
@@ -48,7 +48,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Irene": "Married",
 		"Irene": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Jeric.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Jeric.json
@@ -19,7 +19,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Jeric": "Married",
 		"Jeric": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Jio.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Jio.json
@@ -32,7 +32,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"HasSeenEvent": 75160263,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Jio": "Married",
 		"Jio": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/June.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/June.json
@@ -33,7 +33,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:June": "Married",
 		"June": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Kenneth.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Kenneth.json
@@ -33,7 +33,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Kenneth": "Married",
 		"IsOddYear": true,
 		"Kenneth": "enabled, festivals only",
@@ -47,7 +46,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Kenneth": "Married",
 		"IsOddYear": false,
 		"Kenneth": "enabled, festivals only",

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Kiarra.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Kiarra.json
@@ -34,7 +34,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Kiarra": "Married",
 		"Query: ('{{Kiarra}}' = 'enabled' AND '{{SeasonalKiarraToken}}' = 'true') OR ('{{Kiarra}}' = 'festivals always')": true,
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Maddie.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Maddie.json
@@ -49,7 +49,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Maddie": "Married",
 		"Maddie": "enabled, festivals only",
 		"Query: ('{{Corine}}' = 'enabled' AND '{{SeasonalCorineToken}}' = 'true') OR ('{{Corine}}' = 'festivals always')": true,
@@ -64,7 +63,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Maddie": "Married",
 		"Jeric": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Paula.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Paula.json
@@ -52,7 +52,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Paula": "Married",
 		"Paula": "enabled, festivals only",
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Philip.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Philip.json
@@ -35,7 +35,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Philip": "Married",
 		"IsOddYear": true,
 		"Philip": "enabled, festivals only",
@@ -50,7 +49,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Philip": "Married",
 		"IsOddYear": false,
 		"Philip": "enabled, festivals only",

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Sean.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Sean.json
@@ -34,7 +34,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Sean": "Married",
 		"Query: ('{{Sean}}' = 'enabled' AND '{{SeasonalSeanToken}}' = 'true') OR ('{{Sean}}' = 'festivals always')": true,
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Shiro.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Shiro.json
@@ -35,7 +35,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Shiro": "Married",
 		"IsOddYear": true,
 		"Shiro": "enabled, festivals only",
@@ -50,7 +49,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Shiro": "Married",
 		"IsOddYear": false,
 		"Shiro": "enabled, festivals only",

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Ysabelle.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Ysabelle.json
@@ -58,7 +58,6 @@
    "Target": "Data/Festivals/fall27",
    "When": {
 		"IsOddYear": true,
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Ysabelle": "Married",
 		"Query: ('{{Ysabelle}}' = 'enabled' AND '{{SeasonalYsabelleToken}}' = 'true') OR ('{{Ysabelle}}' = 'festivals always')": true,
 		"Query: ('{{Corine}}' = 'enabled' AND '{{SeasonalCorineToken}}' = 'true') OR ('{{Corine}}' = 'festivals always')": true,
@@ -73,7 +72,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Ysabelle": "Married",
 		"Query: ('{{Ysabelle}}' = 'enabled' AND '{{SeasonalYsabelleToken}}' = 'true') OR ('{{Ysabelle}}' = 'festivals always')": true,
    },

--- a/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Zayne.json
+++ b/Addons/[CP] RSV Seasonal Outfits/Data/DialogueChanges/Zayne.json
@@ -61,7 +61,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Zayne": "Married",
 		"IsOddYear": true,
 		"Zayne": "enabled, festivals only",
@@ -75,7 +74,6 @@
    "Action": "EditData",
    "Target": "Data/Festivals/fall27",
    "When": {
-		"HasMod": "aedenthorn.FreeLove",
    	"Relationship:Zayne": "Married",
 		"IsOddYear": false,
 		"Zayne": "enabled, festivals only",

--- a/Ridgeside Development/[CP] Ridgeside Village/Assets/MarriageDialogue/MarriageDialogueJio.json
+++ b/Ridgeside Development/[CP] Ridgeside Village/Assets/MarriageDialogue/MarriageDialogueJio.json
@@ -76,7 +76,7 @@
 	"funLeave_Jio": "{{i18n:Jio.MarriageDialogue.funLeave_Jio.{{Random: 1, 2, 3, 4}}}}",
 
 //Returning
-	"funReturn_Jio": "{{i18n:Jio.MarriageDialogue.funReturn_Jio_1-1}}[Rafseazz.RSVCP_Arugula_Roll Rafseazz.RSVCP_Fried_Fish_a_la_Ridge Rafseazz.RSVCP_Honey_Ginger_Whitefish Rafseazz.RSVCP_Zesty_Tuna Rafseazz.RSVCP_Fried_Mountain_Greens Rafseazz.RSVCP_Ginger_Arugula_Fried_Rice]#$b#{{i18n:Jio.MarriageDialogue.funReturn_Jio_1-2}}",
+	"funReturn_Jio": "{{i18n:Jio.MarriageDialogue.funReturn.Jio_1-1}}[Rafseazz.RSVCP_Arugula_Roll Rafseazz.RSVCP_Fried_Fish_a_la_Ridge Rafseazz.RSVCP_Honey_Ginger_Whitefish Rafseazz.RSVCP_Zesty_Tuna Rafseazz.RSVCP_Fried_Mountain_Greens Rafseazz.RSVCP_Ginger_Arugula_Fried_Rice]#$b#{{i18n:Jio.MarriageDialogue.funReturn_Jio.1-2}}",
 
 //One kid
 	"OneKid_0": "{{i18n:Jio.MarriageDialogue.OneKid_0}}",

--- a/Ridgeside Development/[CP] Ridgeside Village/Data/Shops.json
+++ b/Ridgeside Development/[CP] Ridgeside Village/Data/Shops.json
@@ -975,7 +975,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem1",
 							"ItemId": "(W)Rafseazz.RSVCP_Amethyst_Lance",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160441, PLAYER_FRIENDSHIP_POINTS Current Zayne 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160440, PLAYER_FRIENDSHIP_POINTS Current Zayne 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -984,7 +984,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem2",
 							"ItemId": "(W)Rafseazz.RSVCP_Ark_Blade",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160392, PLAYER_FRIENDSHIP_POINTS Current Anton 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160304, PLAYER_FRIENDSHIP_POINTS Current Anton 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -993,7 +993,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem3",
 							"ItemId": "(W)Rafseazz.RSVCP_Fairy_Needle",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160454, PLAYER_FRIENDSHIP_POINTS Current Faye 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160449, PLAYER_FRIENDSHIP_POINTS Current Faye 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1002,7 +1002,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem4",
 							"ItemId": "(W)Rafseazz.RSVCP_Guardian_Greatsword",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160455, PLAYER_FRIENDSHIP_POINTS Current Bryle 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160453, PLAYER_FRIENDSHIP_POINTS Current Bryle 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1011,7 +1011,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem5",
 							"ItemId": "(W)Rafseazz.RSVCP_Lovesick",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160432, PLAYER_FRIENDSHIP_POINTS Current Irene 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160324, PLAYER_FRIENDSHIP_POINTS Current Irene 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1020,7 +1020,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem6",
 							"ItemId": "(W)Rafseazz.RSVCP_Military_Saber",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160390, PLAYER_FRIENDSHIP_POINTS Current Paula 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160352, PLAYER_FRIENDSHIP_POINTS Current Paula 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1029,7 +1029,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem7",
 							"ItemId": "(W)Rafseazz.RSVCP_Battery_Powered_Battle_Hammer",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160161, PLAYER_FRIENDSHIP_POINTS Current Kenneth 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160160, PLAYER_FRIENDSHIP_POINTS Current Kenneth 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1038,7 +1038,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem8",
 							"ItemId": "(W)Rafseazz.RSVCP_Battle_Dancer_s_Fan",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160145, PLAYER_FRIENDSHIP_POINTS Current Ysabelle 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160144, PLAYER_FRIENDSHIP_POINTS Current Ysabelle 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1047,7 +1047,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem9",
 							"ItemId": "(W)Rafseazz.RSVCP_Bronze_Lance",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160368, PLAYER_FRIENDSHIP_POINTS Current Sean 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160356, PLAYER_FRIENDSHIP_POINTS Current Sean 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1056,7 +1056,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem10",
 							"ItemId": "(W)Rafseazz.RSVCP_Death_s_Daughter",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160388, PLAYER_FRIENDSHIP_POINTS Current Blair 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160312, PLAYER_FRIENDSHIP_POINTS Current Blair 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1065,7 +1065,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem11",
 							"ItemId": "(W)Rafseazz.RSVCP_Free_Lance",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160365, PLAYER_FRIENDSHIP_POINTS Current Kiarra 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160328, PLAYER_FRIENDSHIP_POINTS Current Kiarra 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1074,7 +1074,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem12",
 							"ItemId": "(W)Rafseazz.RSVCP_Heartbreaker",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160139, PLAYER_FRIENDSHIP_POINTS Current Maddie 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160136, PLAYER_FRIENDSHIP_POINTS Current Maddie 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1083,7 +1083,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem13",
 							"ItemId": "(W)Rafseazz.RSVCP_Icreon",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160127, PLAYER_FRIENDSHIP_POINTS Current Corine 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160125, PLAYER_FRIENDSHIP_POINTS Current Corine 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1092,7 +1092,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem14",
 							"ItemId": "(W)Rafseazz.RSVCP_Laborforce",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160150, PLAYER_FRIENDSHIP_POINTS Current Ian 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160149, PLAYER_FRIENDSHIP_POINTS Current Ian 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1101,7 +1101,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem15",
 							"ItemId": "(W)Rafseazz.RSVCP_Observer_s_Hatchet",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160133, PLAYER_FRIENDSHIP_POINTS Current Flor 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160132, PLAYER_FRIENDSHIP_POINTS Current Flor 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1110,7 +1110,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem16",
 							"ItemId": "(W)Rafseazz.RSVCP_Sword_of_Idols",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160167, PLAYER_FRIENDSHIP_POINTS Current Philip 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160166, PLAYER_FRIENDSHIP_POINTS Current Philip 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1119,7 +1119,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem17",
 							"ItemId": "(W)Rafseazz.RSVCP_The_Lucky_Penny",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160155, PLAYER_FRIENDSHIP_POINTS Current Jeric 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160154, PLAYER_FRIENDSHIP_POINTS Current Jeric 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1128,7 +1128,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem18",
 							"ItemId": "(W)Rafseazz.RSVCP_The_Singing_Dagger",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160121, PLAYER_FRIENDSHIP_POINTS Current Alissa 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160120, PLAYER_FRIENDSHIP_POINTS Current Alissa 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1137,7 +1137,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem19",
 							"ItemId": "(W)Rafseazz.RSVCP_The_Unbroken",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160172, PLAYER_FRIENDSHIP_POINTS Current Shiro 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160171, PLAYER_FRIENDSHIP_POINTS Current Shiro 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1146,7 +1146,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem20",
 							"ItemId": "(W)Rafseazz.RSVCP_Treble_Cleaver",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 94620010, PLAYER_FRIENDSHIP_POINTS Current June 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 94620008, PLAYER_FRIENDSHIP_POINTS Current June 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1208,7 +1208,7 @@
 						{
 							"Id": "{{ModId}}.SacrificeFallsItem5",
 							"ItemId": "(W)Rafseazz.RSVCP_Dusked_Kunai",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160208, PLAYER_FRIENDSHIP_POINTS Current Daia 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160205, PLAYER_FRIENDSHIP_POINTS Current Daia 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1226,7 +1226,7 @@
 						{
 							"Id": "{{ModId}}.SacrificeFallsItem7",
 							"ItemId": "(W)Rafseazz.RSVCP_Occult_Blade",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160200, PLAYER_FRIENDSHIP_POINTS Current Jio 2500",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160081, PLAYER_FRIENDSHIP_POINTS Current Jio 2000",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50

--- a/Ridgeside Development/[CP] Ridgeside Village/Data/Shops.json
+++ b/Ridgeside Development/[CP] Ridgeside Village/Data/Shops.json
@@ -975,7 +975,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem1",
 							"ItemId": "(W)Rafseazz.RSVCP_Amethyst_Lance",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160440, PLAYER_FRIENDSHIP_POINTS Current Zayne 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160441, PLAYER_FRIENDSHIP_POINTS Current Zayne 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -984,7 +984,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem2",
 							"ItemId": "(W)Rafseazz.RSVCP_Ark_Blade",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160304, PLAYER_FRIENDSHIP_POINTS Current Anton 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160392, PLAYER_FRIENDSHIP_POINTS Current Anton 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -993,7 +993,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem3",
 							"ItemId": "(W)Rafseazz.RSVCP_Fairy_Needle",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160449, PLAYER_FRIENDSHIP_POINTS Current Faye 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160454, PLAYER_FRIENDSHIP_POINTS Current Faye 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1002,7 +1002,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem4",
 							"ItemId": "(W)Rafseazz.RSVCP_Guardian_Greatsword",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160453, PLAYER_FRIENDSHIP_POINTS Current Bryle 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160455, PLAYER_FRIENDSHIP_POINTS Current Bryle 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1011,7 +1011,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem5",
 							"ItemId": "(W)Rafseazz.RSVCP_Lovesick",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160324, PLAYER_FRIENDSHIP_POINTS Current Irene 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160432, PLAYER_FRIENDSHIP_POINTS Current Irene 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1020,7 +1020,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem6",
 							"ItemId": "(W)Rafseazz.RSVCP_Military_Saber",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160352, PLAYER_FRIENDSHIP_POINTS Current Paula 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160390, PLAYER_FRIENDSHIP_POINTS Current Paula 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1029,7 +1029,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem7",
 							"ItemId": "(W)Rafseazz.RSVCP_Battery_Powered_Battle_Hammer",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160160, PLAYER_FRIENDSHIP_POINTS Current Kenneth 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160161, PLAYER_FRIENDSHIP_POINTS Current Kenneth 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1038,7 +1038,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem8",
 							"ItemId": "(W)Rafseazz.RSVCP_Battle_Dancer_s_Fan",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160144, PLAYER_FRIENDSHIP_POINTS Current Ysabelle 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160145, PLAYER_FRIENDSHIP_POINTS Current Ysabelle 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1047,7 +1047,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem9",
 							"ItemId": "(W)Rafseazz.RSVCP_Bronze_Lance",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160356, PLAYER_FRIENDSHIP_POINTS Current Sean 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160368, PLAYER_FRIENDSHIP_POINTS Current Sean 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1056,7 +1056,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem10",
 							"ItemId": "(W)Rafseazz.RSVCP_Death_s_Daughter",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160312, PLAYER_FRIENDSHIP_POINTS Current Blair 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160388, PLAYER_FRIENDSHIP_POINTS Current Blair 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1065,7 +1065,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem11",
 							"ItemId": "(W)Rafseazz.RSVCP_Free_Lance",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160328, PLAYER_FRIENDSHIP_POINTS Current Kiarra 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160365, PLAYER_FRIENDSHIP_POINTS Current Kiarra 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1074,7 +1074,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem12",
 							"ItemId": "(W)Rafseazz.RSVCP_Heartbreaker",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160136, PLAYER_FRIENDSHIP_POINTS Current Maddie 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160139, PLAYER_FRIENDSHIP_POINTS Current Maddie 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1083,7 +1083,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem13",
 							"ItemId": "(W)Rafseazz.RSVCP_Icreon",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160125, PLAYER_FRIENDSHIP_POINTS Current Corine 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160127, PLAYER_FRIENDSHIP_POINTS Current Corine 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1092,7 +1092,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem14",
 							"ItemId": "(W)Rafseazz.RSVCP_Laborforce",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160149, PLAYER_FRIENDSHIP_POINTS Current Ian 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160150, PLAYER_FRIENDSHIP_POINTS Current Ian 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1101,7 +1101,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem15",
 							"ItemId": "(W)Rafseazz.RSVCP_Observer_s_Hatchet",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160132, PLAYER_FRIENDSHIP_POINTS Current Flor 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160133, PLAYER_FRIENDSHIP_POINTS Current Flor 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1110,7 +1110,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem16",
 							"ItemId": "(W)Rafseazz.RSVCP_Sword_of_Idols",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160166, PLAYER_FRIENDSHIP_POINTS Current Philip 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160167, PLAYER_FRIENDSHIP_POINTS Current Philip 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1119,7 +1119,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem17",
 							"ItemId": "(W)Rafseazz.RSVCP_The_Lucky_Penny",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160154, PLAYER_FRIENDSHIP_POINTS Current Jeric 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160155, PLAYER_FRIENDSHIP_POINTS Current Jeric 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1128,7 +1128,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem18",
 							"ItemId": "(W)Rafseazz.RSVCP_The_Singing_Dagger",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160120, PLAYER_FRIENDSHIP_POINTS Current Alissa 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160121, PLAYER_FRIENDSHIP_POINTS Current Alissa 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1137,7 +1137,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem19",
 							"ItemId": "(W)Rafseazz.RSVCP_The_Unbroken",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160171, PLAYER_FRIENDSHIP_POINTS Current Shiro 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160172, PLAYER_FRIENDSHIP_POINTS Current Shiro 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1146,7 +1146,7 @@
 						{
 							"Id": "{{ModId}}.LoveFallsItem20",
 							"ItemId": "(W)Rafseazz.RSVCP_Treble_Cleaver",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 94620008, PLAYER_FRIENDSHIP_POINTS Current June 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 94620010, PLAYER_FRIENDSHIP_POINTS Current June 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1208,7 +1208,7 @@
 						{
 							"Id": "{{ModId}}.SacrificeFallsItem5",
 							"ItemId": "(W)Rafseazz.RSVCP_Dusked_Kunai",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160205, PLAYER_FRIENDSHIP_POINTS Current Daia 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160208, PLAYER_FRIENDSHIP_POINTS Current Daia 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50
@@ -1226,7 +1226,7 @@
 						{
 							"Id": "{{ModId}}.SacrificeFallsItem7",
 							"ItemId": "(W)Rafseazz.RSVCP_Occult_Blade",
-							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160081, PLAYER_FRIENDSHIP_POINTS Current Jio 2000",
+							"Condition": "PLAYER_HAS_SEEN_EVENT Current 75160200, PLAYER_FRIENDSHIP_POINTS Current Jio 2500",
 
 							"TradeItemId": "(O)Rafseazz.RSVCP_Spiritual_Essence",
 							"TradeItemAmount": 50

--- a/Ridgeside Development/[CP] Ridgeside Village/i18n/default.json
+++ b/Ridgeside Development/[CP] Ridgeside Village/i18n/default.json
@@ -142,7 +142,7 @@ I've put random lines of appreciation to my team everywhere here. If you're a tr
 "niece_alissa": "niece Alissa",
 "uncle": "uncle",
 "grandmother": "grandmother",
-"granddaughter": "granddaughter",
+
 
 
 

--- a/Ridgeside Development/[CP] Ridgeside Village/i18n/default.json
+++ b/Ridgeside Development/[CP] Ridgeside Village/i18n/default.json
@@ -142,7 +142,7 @@ I've put random lines of appreciation to my team everywhere here. If you're a tr
 "niece_alissa": "niece Alissa",
 "uncle": "uncle",
 "grandmother": "grandmother",
-
+"granddaughter": "granddaughter",
 
 
 

--- a/Ridgeside Development/[CP] Ridgeside Village/i18n/default.json
+++ b/Ridgeside Development/[CP] Ridgeside Village/i18n/default.json
@@ -16180,7 +16180,7 @@ I've put random lines of appreciation to my team everywhere here. If you're a tr
 "Romance.Engagement.Blair0": "You really couldn't wait to put a ring on me, huh?$6#$b#My, my. You must be smitten with me. Haha!$4",
 "Romance.Engagement.Blair1": "Mom would freak if she knew about this!$h#$b#Get ready to get a big hug and kiss from her!$h#$b#That woman has no boundaries for family!$u#$b#Haha!$h",
 "Romance.give.flowersA.Blair": "Oh!$h#$b#But of course, you'd like to be with the most beautiful woman in the valley.$4#$b#It must be a good thing I'm accepting your offer, right, babe?$h",
-"Romance.give.flowersB.Blair": "Why yes!$h#$b#I accept your proposal to be in a relationship l, @!$h",
+"Romance.give.flowersB.Blair": "Why yes!$h#$b#I accept your proposal to be in a relationship, @!$h",
 "Romance.stardrop.gift.Blair": "Here's a little gift for the best present in my presence.$h#$b#Aren't I witty, babe?$h",
 "Romance.rejectNPCA.Blair": "Ay no!$u#$b#I'm sorry but you must have the wrong idea.#$b#I cannot stress enough that I don't like you like that. I'm sorry.$s",
 "Romance.rejectNPCB.Blair": "Ayayay. I was afraid of this happening.$s#$b#I know people like yourself adore me, but I don't like you in that way, @.$7#$b#I think it'll be better if we're just friends.",

--- a/Ridgeside Development/changelog.txt
+++ b/Ridgeside Development/changelog.txt
@@ -1,15 +1,6 @@
-RSV 2.5.12 - Dog ate my homework
-------------------------------------------------------
-Fixed bug during Ezekiel's 4 heart event
-Fixed bug where Summit Iced Tea didn't have a recipe
-Fixed bug where RSV NPCs disappear during even years when certain mods are installed
-Fixes to quests
-
 RSV 2.5.11 - My socks are mismatched
 ------------------------------------------------------
 Added winter outfits for most of the RSV NPCs
-Changed Mystic Falls of Love requirements from 10 to 8 hearts per NPC
-Changed Mystic Falls of Love requirements from 10 heart events to 8 heart events per NPC except Maddie (requires 6 heart event)
 Fixed bug where RSV fish only produce roe when put in fishponds
 Fix Ice Festival NPC placement bugs
 Fixed Green Rain schedules

--- a/Ridgeside Development/changelog.txt
+++ b/Ridgeside Development/changelog.txt
@@ -1,6 +1,15 @@
+RSV 2.5.12 - Dog ate my homework
+------------------------------------------------------
+Fixed bug during Ezekiel's 4 heart event
+Fixed bug where Summit Iced Tea didn't have a recipe
+Fixed bug where RSV NPCs disappear during even years when certain mods are installed
+Fixes to quests
+
 RSV 2.5.11 - My socks are mismatched
 ------------------------------------------------------
 Added winter outfits for most of the RSV NPCs
+Changed Mystic Falls of Love requirements from 10 to 8 hearts per NPC
+Changed Mystic Falls of Love requirements from 10 heart events to 8 heart events per NPC except Maddie (requires 6 heart event)
 Fixed bug where RSV fish only produce roe when put in fishponds
 Fix Ice Festival NPC placement bugs
 Fixed Green Rain schedules


### PR DESCRIPTION
Fixes Poly compat in RSV Seasonals to not require Free Love itself (since to be married to them and not be spouse means a poly mod is used) as well as fixes a no translation bug with Jio.