### PR TITLE
Implement support for Better Game Menu

### DIFF
--- a/Ridgeside SMAPI Component 2.0/RidgesideVillage/Map/RSVWorldMap.cs
+++ b/Ridgeside SMAPI Component 2.0/RidgesideVillage/Map/RSVWorldMap.cs
@@ -37,9 +37,9 @@ namespace RidgesideVillage
             Helper = helper;
         }
 
-        internal static void Open(IClickableMenu gameMenu)
+        internal static void Open(IClickableMenu menu)
         {
-            if (gameMenu is GameMenu menu)
+            if (menu is not null)
             {
                 Texture2D image = Helper.GameContent.Load<Texture2D>(MapPath);
                 Vector2 topLeft = Utility.getTopLeftPositionForCenteringOnScreen((int)(image.Width * 5), (int)(image.Height * 5));

--- a/Ridgeside SMAPI Component 2.0/RidgesideVillage/Patches/EventDetection.cs
+++ b/Ridgeside SMAPI Component 2.0/RidgesideVillage/Patches/EventDetection.cs
@@ -29,11 +29,6 @@ namespace RidgesideVillage
         {
             Helper = helper;
 
-            Log.Trace($"Applying Harmony Patch \"{nameof(GameMenu_ChangeTab_PostFix)}.");
-            harmony.Patch(
-                original: AccessTools.Method(typeof(GameMenu), nameof(GameMenu.changeTab)),
-                prefix: new HarmonyMethod(typeof(EventDetection), nameof(GameMenu_ChangeTab_PostFix))
-            );
             harmony.Patch(
                 original: AccessTools.Method(typeof(MapPage), nameof(MapPage.draw), new Type[]{ typeof(SpriteBatch)}),
                 postfix: new HarmonyMethod(typeof(EventDetection), nameof(MapPage_draw_Postfix))
@@ -53,8 +48,15 @@ namespace RidgesideVillage
                 upNeighborID = 1001
             };
 
+            Helper.Events.Display.MenuChanged += OnMenuChanged;
             Helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
             Helper.Events.Display.WindowResized += OnWindowResized;
+        }
+
+        private static void OnMenuChanged(object sender, MenuChangedEventArgs e)
+        {
+            //only draw on vanilla or cablecar map
+            ShouldDraw = ModEntry.Config.ShowRSVCustomMap && Game1.currentLocation?.Name is not null && (!Game1.currentLocation.Name.Contains('_') || Game1.currentLocation.Name == RSVConstants.L_CABLECAR);
         }
 
         private static void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
@@ -76,18 +78,6 @@ namespace RidgesideVillage
             RSVButton.bounds = ButtonArea;
         }
 
-        internal static void GameMenu_ChangeTab_PostFix(ref GameMenu __instance, int whichTab, bool playSound = true)
-        {
-            try
-            {
-                //only draw on vanilla or cablecar map
-                ShouldDraw = ModEntry.Config.ShowRSVCustomMap && (!Game1.currentLocation.Name.Contains('_') || Game1.currentLocation.Name == RSVConstants.L_CABLECAR);
-            }
-            catch (Exception e)
-            {
-                Log.Error($"Harmony patch \"{nameof(GameMenu_ChangeTab_PostFix)}\" has encountered an error. \n{e.ToString()}");
-            }
-        }
 
         internal static void MapPage_draw_Postfix(ref MapPage __instance, SpriteBatch b) {
             if (!ShouldDraw)


### PR DESCRIPTION
Hello!

[Better Game Menu](https://github.com/KhloeLeclair/StardewMods/releases/tag/BetterGameMenu-Preview3) is a new mod I'm going to be releasing that replaces `GameMenu` with a replacement that:

1. Is considerably more efficient by virtue of only creating page instances when the pages are actually accessed.
2. Has a robust API to let other mods work with the game menu, making it easy to register new tabs, override existing tabs, and respond to events involving the menu.

I realize this has the potential to break a lot of things, so I'm going to be submitting PRs to various mods that interact with GameMenu to implement support for BetterGameMenu. This is such a PR.

---

This is an interesting case because Ridgeside's C# component doesn't really *need* `GameMenu` for anything. You were using it in two places:

1. Using a Harmony patch to check when the current tab of a `GameMenu` instance changes, to recalculate whether or not the Ridgeside component should be rendered on top of `MapPages`. But the calculation only cares about the current game location. I moved this into a `MenuChanged` event handler which both doesn't require a Harmony patch and is compatible with Better Game Menu.

2. In the method to open the Ridgeside sub-map, it was checking if the currently active menu is a `GameMenu` before setting its child menu. This is entirely unnecessary, since all menus support the child menu system. Instead, I've just added a basic `null` check to be safe.

---

As an aside, you should probably be using `PerScreen<>` in `EventDetection` to support local co-op via split screen, but changing that is outside the scope of this PR.

I hope this is helpful. Please contact me if you have any questions!