### PR TITLE
Fix invalid map property in RSVOpenPlot.tmx

### DIFF
--- a/Ridgeside Development/[CP] Ridgeside Village/Assets/Maps/EventMaps/RSVOpenPlot.tmx
+++ b/Ridgeside Development/[CP] Ridgeside Village/Assets/Maps/EventMaps/RSVOpenPlot.tmx
@@ -2,8 +2,8 @@
 <map version="1.5" tiledversion="1.5.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="3" height="2" tilewidth="16" tileheight="16" infinite="0" nextlayerid="11" nextobjectid="2249">
  <properties>
   <property name="Light" value="143 26 4 126 22 4 118 26 4 111 26 4 100 26 4 121 41 4 107 41 4 124 49 4 135 49 4 108 53 4 114 53 4 87 85 4 81 85 4 80 100 4 87 110 4 8 61 4 50 121 4 9 119 4 37 56 4 51 42 4 56 36 4 46 27 4 65 18 4 79 16 4 89 26 4 95 14 4 101 6 4 93 1 4 79 54 4 79 62 4 88 57 4 85 62 4 94 57 4 91 62 4 72 57 4 73 52 4 70 14 4"/>
-  <property name="NightTiles">AlwaysFront 143 26 908 AlwaysFront 126 22 908 AlwaysFront 118 26 908 AlwaysFront 111 26 908 AlwaysFront 100 26 908 AlwaysFront 121 41 908 AlwaysFront 107 41 908 AlwaysFront 124 49 908 AlwaysFront 135 49 908 AlwaysFront 108 53 908 AlwaysFront 114 53 908 AlwaysFront 87 85 908 AlwaysFront 81 85 908 AlwaysFront 80 100 908 AlwaysFront 87 110 908 AlwaysFront 8 61 908 AlwaysFront 50 121 908 AlwaysFront 9 119 908 AlwaysFront 37 56 908 AlwaysFront 51 42 908 AlwaysFront 56 36 908 AlwaysFront 46 27 908 AlwaysFront 65 18 908 AlwaysFront 79 16 908 
-AlwaysFront 89 26 908 AlwaysFront 95 14 908 AlwaysFront 101 6 908 AlwaysFront 93 1 908 Front 70 14 507</property>
+  <property name="NightTiles" value="AlwaysFront 143 26 908 AlwaysFront 126 22 908 AlwaysFront 118 26 908 AlwaysFront 111 26 908 AlwaysFront 100 26 908 AlwaysFront 121 41 908 AlwaysFront 107 41 908 AlwaysFront 124 49 908 AlwaysFront 135 49 908 AlwaysFront 108 53 908 AlwaysFront 114 53 908 AlwaysFront 87 85 908 AlwaysFront 81 85 908 AlwaysFront 80 100 908 AlwaysFront 87 110 908 AlwaysFront 8 61 908 AlwaysFront 50 121 908 AlwaysFront 9 119 908 AlwaysFront 37 56 908 AlwaysFront 51 42 908 AlwaysFront 56 36 908 AlwaysFront 46 27 908 AlwaysFront 65 18 908 AlwaysFront 79 16 908 
+AlwaysFront 89 26 908 AlwaysFront 95 14 908 AlwaysFront 101 6 908 AlwaysFront 93 1 908 Front 70 14 507" />
   <property name="Outdoors" type="bool" value="true"/>
  </properties>
  <tileset firstgid="1" name="Landscape" tilewidth="16" tileheight="16" tilecount="1975" columns="25">


### PR DESCRIPTION
Fixes issues where this map cannot be exported due to being invalid.

It doesn't cause any game errors as stardew has extra null checks for this property, but does prevent patch export (and Speedy Solutions TBin exporter) from working as a result.